### PR TITLE
Add rust-analyzer to rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "nightly-2025-03-12" # duplicated in github action
 targets = ["wasm32-unknown-unknown"]
+components = ["rust-analyzer"]


### PR DESCRIPTION
This is necessary for LSP to work out of the box for people who use a rustup-provided version of rust-analyzer (e.g. me).