### PR TITLE
Reset and reload store on auth changes

### DIFF
--- a/app/src/auth/guard.rs
+++ b/app/src/auth/guard.rs
@@ -1,28 +1,40 @@
 use leptos::prelude::*;
 use leptos_router::hooks::{use_location, use_navigate};
 
-use crate::auth::use_token;
+use crate::{
+    auth::use_token,
+    state::{use_store, Action},
+};
 
 /// Navigates to the login page if token is unset and the home page if token is
 /// set to a new value.
 pub fn create_auth_guard() {
     let token = use_token();
     let location = use_location();
+    let store = use_store();
 
     Effect::new(move |_| {
         let navigate = use_navigate();
         let location = location.pathname.get();
         if token.get().into_inner().is_none() {
+            // purge all user data
+            store.dispatch(Action::Reset);
+
             // workaround for navigating during initial routing
             // https://docs.rs/leptos_router/0.4.2/leptos_router/fn.use_navigate.html#panics
             request_animation_frame(move || {
                 navigate("/login", Default::default());
             });
-        } else if location == "/login" {
-            // we probably just logged in, move from login page to home
-            request_animation_frame(move || {
-                navigate("/", Default::default());
-            });
+        } else {
+            // token changed to a new user, reload all data
+            store.dispatch(Action::Reload);
+
+            if location == "/login" {
+                // we probably just logged in, move from login page to home
+                request_animation_frame(move || {
+                    navigate("/", Default::default());
+                });
+            }
         }
     });
 }

--- a/app/src/state/middleware.rs
+++ b/app/src/state/middleware.rs
@@ -17,6 +17,7 @@ use crate::auth::Token;
 use super::{action::Action, State};
 
 pub enum PreMiddlewareAction {
+    Reset,
     Reload,
     SubmitPage(Page),
     SubmitWidget(Widget),
@@ -28,6 +29,7 @@ pub enum PreMiddlewareAction {
 
 pub async fn process(action: PreMiddlewareAction, token: &Token) -> Action {
     match action {
+        PreMiddlewareAction::Reset => Action::Overwrite(State::default()),
         PreMiddlewareAction::Reload => {
             let settings = fetch_settings(token).await;
             let pages = fetch_all::<Page>(token).await;


### PR DESCRIPTION
This ensures newly-logged-in users don't see stale data of a previously-logged-in user and that their data is actually fetched on initial login. Admittedly, the former situation should be rare, but it's still good to do things correctly.